### PR TITLE
swap with two pairs from single token

### DIFF
--- a/auto-farm/multicontract.toml
+++ b/auto-farm/multicontract.toml
@@ -1,0 +1,4 @@
+[contracts.full]
+name = "auto-farm"
+add-unlabelled = true
+add-labels = [ "farm-whitelist-endpoints", "metastaking-whitelist-endpoints"]

--- a/auto-farm/src/external_storage_read/farm_storage_read.rs
+++ b/auto-farm/src/external_storage_read/farm_storage_read.rs
@@ -19,6 +19,7 @@ pub struct FarmConfig<M: ManagedTypeApi> {
 
 #[elrond_wasm::module]
 pub trait FarmStorageReadModule: utils::UtilsModule {
+    #[label("farm-whitelist-endpoints")]
     #[view(getFarmConfig)]
     fn get_farm_config(&self, farm_address: &ManagedAddress) -> FarmConfig<Self::Api> {
         let state = self.farm_state().get_from_address(farm_address);

--- a/auto-farm/src/external_storage_read/metastaking_storage_read.rs
+++ b/auto-farm/src/external_storage_read/metastaking_storage_read.rs
@@ -9,6 +9,7 @@ pub struct MetastakingConfig<M: ManagedTypeApi> {
 
 #[elrond_wasm::module]
 pub trait MetastakingStorageReadModule: utils::UtilsModule {
+    #[label("metastaking-whitelist-endpoints")]
     #[view(getMetastakingConfig)]
     fn get_metastaking_config(
         &self,

--- a/auto-farm/src/whitelists/farms_whitelist.rs
+++ b/auto-farm/src/whitelists/farms_whitelist.rs
@@ -9,6 +9,7 @@ pub trait FarmsWhitelistModule:
     crate::external_storage_read::farm_storage_read::FarmStorageReadModule + utils::UtilsModule
 {
     /// Can also be used for farm-staking contracts.
+    #[label("farm-whitelist-endpoints")]
     #[only_owner]
     #[endpoint(addFarms)]
     fn add_farms(&self, farms: MultiValueEncoded<ManagedAddress>) {
@@ -30,6 +31,7 @@ pub trait FarmsWhitelistModule:
         }
     }
 
+    #[label("farm-whitelist-endpoints")]
     #[only_owner]
     #[endpoint(removeFarms)]
     fn remove_farms(&self, farms: MultiValueEncoded<ManagedAddress>) {
@@ -47,6 +49,7 @@ pub trait FarmsWhitelistModule:
         }
     }
 
+    #[label("farm-whitelist-endpoints")]
     #[view(getFarmForFarmToken)]
     fn get_farm_for_farm_token_view(
         &self,
@@ -56,6 +59,7 @@ pub trait FarmsWhitelistModule:
         self.farm_ids().get_address(farm_id).into()
     }
 
+    #[label("farm-whitelist-endpoints")]
     #[view(getFarmForFarmingToken)]
     fn get_farm_for_farming_token_view(
         &self,

--- a/auto-farm/src/whitelists/metastaking_whitelist.rs
+++ b/auto-farm/src/whitelists/metastaking_whitelist.rs
@@ -7,6 +7,7 @@ pub trait MetastakingWhitelistModule:
     crate::external_storage_read::metastaking_storage_read::MetastakingStorageReadModule
     + utils::UtilsModule
 {
+    #[label("metastaking-whitelist-endpoints")]
     #[only_owner]
     #[endpoint(addMetastakingScs)]
     fn add_metastaking_scs(&self, scs: MultiValueEncoded<ManagedAddress>) {
@@ -23,6 +24,7 @@ pub trait MetastakingWhitelistModule:
         }
     }
 
+    #[label("metastaking-whitelist-endpoints")]
     #[only_owner]
     #[endpoint(removeMetastakingScs)]
     fn remove_metastaking_scs(&self, scs: MultiValueEncoded<ManagedAddress>) {
@@ -41,6 +43,7 @@ pub trait MetastakingWhitelistModule:
         }
     }
 
+    #[label("metastaking-whitelist-endpoints")]
     #[view(getMetastakingForDualYieldToken)]
     fn get_metastaking_for_dual_yield_token_view(
         &self,
@@ -52,6 +55,7 @@ pub trait MetastakingWhitelistModule:
         self.metastaking_ids().get_address(ms_id).into()
     }
 
+    #[label("metastaking-whitelist-endpoints")]
     #[view(getMetastakingForLpFarmToken)]
     fn get_metastaking_for_lp_farm_token(
         &self,

--- a/auto-farm/wasm/src/lib.rs
+++ b/auto-farm/wasm/src/lib.rs
@@ -15,10 +15,6 @@ elrond_wasm_node::wasm_endpoints! {
     auto_farm
     (
         changeProxyClaimAddress
-        addFarms
-        removeFarms
-        getFarmForFarmToken
-        getFarmForFarmingToken
         getFarmConfig
         register
         withdrawAllAndUnregister
@@ -26,10 +22,6 @@ elrond_wasm_node::wasm_endpoints! {
         withdrawAllFarmTokens
         withdrawSpecificFarmTokens
         getUserFarmTokens
-        addMetastakingScs
-        removeMetastakingScs
-        getMetastakingForDualYieldToken
-        getMetastakingForLpFarmToken
         depositMetastakingTokens
         withdrawAllMetastakingTokens
         withdrawSpecificMetastakingTokens
@@ -43,6 +35,14 @@ elrond_wasm_node::wasm_endpoints! {
         getAccumulatedFees
         setEnergyFactoryAddress
         getEnergyFactoryAddress
+        addFarms
+        removeFarms
+        getFarmForFarmToken
+        getFarmForFarmingToken
+        addMetastakingScs
+        removeMetastakingScs
+        getMetastakingForDualYieldToken
+        getMetastakingForLpFarmToken
     )
 }
 

--- a/auto-pos-creator/Cargo.toml
+++ b/auto-pos-creator/Cargo.toml
@@ -18,6 +18,28 @@ version = "=0.38.0"
 [dev-dependencies.elrond-wasm-debug]
 version = "=0.38.0"
 
+# Local dependencies
+[dependencies]
+auto-farm = { path = "../auto-farm" }
+
+# Farm dependencies
+farm = { git = "https://github.com/multiversx/mx-exchange-sc", rev = "7b6564f" }
+farm-with-locked-rewards = { git = "https://github.com/multiversx/mx-exchange-sc", rev = "7b6564f" }
+farm-staking = { git = "https://github.com/multiversx/mx-exchange-sc", rev = "7b6564f" }
+farm-staking-proxy = { git = "https://github.com/multiversx/mx-exchange-sc", rev = "7b6564f" }
+
+# Other SCs
+pair = { git = "https://github.com/multiversx/mx-exchange-sc", rev = "7b6564f" }
+energy-factory = { git = "https://github.com/multiversx/mx-exchange-sc", rev = "7b6564f" }
+
+# Common modules/types
+common_structs = { git = "https://github.com/multiversx/mx-exchange-sc", rev = "7b6564f" }
+mergeable = { git = "https://github.com/multiversx/mx-exchange-sc", rev = "7b6564f" }
+utils = { git = "https://github.com/multiversx/mx-exchange-sc", rev = "7b6564f" }
+energy-query = { git = "https://github.com/multiversx/mx-exchange-sc", rev = "7b6564f" }
+legacy_token_decode_module = { git = "https://github.com/multiversx/mx-exchange-sc", rev = "7b6564f" }
+lkmex-transfer = { git = "https://github.com/multiversx/mx-exchange-sc", rev = "7b6564f" }
+
 [dev-dependencies]
 num-bigint = "0.4.2"
 num-traits = "0.2"

--- a/auto-pos-creator/multicontract.toml
+++ b/auto-pos-creator/multicontract.toml
@@ -1,0 +1,4 @@
+[contracts.full]
+name = "auto-pos-creator"
+add-unlabelled = true
+add-labels = []

--- a/auto-pos-creator/src/configs/auto_farm_config.rs
+++ b/auto-pos-creator/src/configs/auto_farm_config.rs
@@ -1,0 +1,7 @@
+elrond_wasm::imports!();
+
+#[elrond_wasm::module]
+pub trait AutoFarmConfigModule {
+    #[storage_mapper("autoFarmScAddress")]
+    fn auto_farm_sc_address(&self) -> SingleValueMapper<ManagedAddress>;
+}

--- a/auto-pos-creator/src/configs/mod.rs
+++ b/auto-pos-creator/src/configs/mod.rs
@@ -1,0 +1,2 @@
+pub mod auto_farm_config;
+pub mod pairs_config;

--- a/auto-pos-creator/src/configs/pairs_config.rs
+++ b/auto-pos-creator/src/configs/pairs_config.rs
@@ -1,0 +1,80 @@
+elrond_wasm::imports!();
+
+pub struct PairConfig<M: ManagedTypeApi> {
+    pub first_token_id: TokenIdentifier<M>,
+    pub second_token_id: TokenIdentifier<M>,
+}
+
+#[elrond_wasm::module]
+pub trait PairsConfigModule: utils::UtilsModule {
+    #[only_owner]
+    #[endpoint(addPairsToWhitelist)]
+    fn add_pairs_to_whitelist(&self, pair_addresses: MultiValueEncoded<ManagedAddress>) {
+        for pair_address in pair_addresses {
+            self.require_sc_address(&pair_address);
+
+            let config = self.get_pair_config(&pair_address);
+            let token_pair_mapper =
+                self.pair_address_for_tokens(&config.first_token_id, &config.second_token_id);
+            require!(token_pair_mapper.is_empty(), "Token pair already known");
+
+            token_pair_mapper.set(&pair_address);
+        }
+    }
+
+    #[only_owner]
+    #[endpoint(removePairsFromWhitelist)]
+    fn remove_pairs_from_whitelist(&self, pair_addresses: MultiValueEncoded<ManagedAddress>) {
+        for pair_address in pair_addresses {
+            self.require_sc_address(&pair_address);
+
+            let config = self.get_pair_config(&pair_address);
+            self.pair_address_for_tokens(&config.first_token_id, &config.second_token_id)
+                .clear();
+        }
+    }
+
+    fn get_pair_config(&self, pair_address: &ManagedAddress) -> PairConfig<Self::Api> {
+        let first_token_id = self.first_token_id().get_from_address(pair_address);
+        let second_token_id = self.second_token_id().get_from_address(pair_address);
+
+        self.require_valid_token_id(&first_token_id);
+        self.require_valid_token_id(&second_token_id);
+
+        PairConfig {
+            first_token_id,
+            second_token_id,
+        }
+    }
+
+    fn get_pair_address_for_tokens(
+        &self,
+        first_token_id: &TokenIdentifier,
+        second_token_id: &TokenIdentifier,
+    ) -> ManagedAddress {
+        let correct_order_mapper = self.pair_address_for_tokens(first_token_id, second_token_id);
+        if !correct_order_mapper.is_empty() {
+            return correct_order_mapper.get();
+        }
+
+        let reverse_order_mapper = self.pair_address_for_tokens(second_token_id, first_token_id);
+        require!(!reverse_order_mapper.is_empty(), "No pair for given tokens");
+
+        reverse_order_mapper.get()
+    }
+
+    #[storage_mapper("pairAddrForTokens")]
+    fn pair_address_for_tokens(
+        &self,
+        first_token_id: &TokenIdentifier,
+        second_token_id: &TokenIdentifier,
+    ) -> SingleValueMapper<ManagedAddress>;
+
+    // Pair storage
+
+    #[storage_mapper("first_token_id")]
+    fn first_token_id(&self) -> SingleValueMapper<TokenIdentifier>;
+
+    #[storage_mapper("second_token_id")]
+    fn second_token_id(&self) -> SingleValueMapper<TokenIdentifier>;
+}

--- a/auto-pos-creator/src/external_sc_interactions/mod.rs
+++ b/auto-pos-creator/src/external_sc_interactions/mod.rs
@@ -1,0 +1,2 @@
+pub mod multi_contract_interactions;
+pub mod pair_actions;

--- a/auto-pos-creator/src/external_sc_interactions/multi_contract_interactions.rs
+++ b/auto-pos-creator/src/external_sc_interactions/multi_contract_interactions.rs
@@ -1,0 +1,19 @@
+elrond_wasm::imports!();
+
+#[elrond_wasm::module]
+pub trait MultiContractInteractionsModule:
+    super::pair_actions::PairActionsModule
+    + crate::configs::pairs_config::PairsConfigModule
+    + utils::UtilsModule
+{
+    #[endpoint(createPosFromSingleToken)]
+    fn create_pos_from_single_token(&self, dest_pair_address: ManagedAddress) {
+        let payment = self.call_value().single_esdt();
+        let double_swap_result = self.buy_half_each_token(payment, &dest_pair_address);
+        let _add_liq_result = self.call_pair_add_liquidity(
+            dest_pair_address,
+            double_swap_result.first_swap_tokens,
+            double_swap_result.second_swap_tokens,
+        );
+    }
+}

--- a/auto-pos-creator/src/external_sc_interactions/pair_actions.rs
+++ b/auto-pos-creator/src/external_sc_interactions/pair_actions.rs
@@ -1,0 +1,124 @@
+use pair::AddLiquidityResultType;
+
+elrond_wasm::imports!();
+
+const MIN_AMOUNT_OUT: u32 = 1;
+
+pub struct DoubleSwapResult<M: ManagedTypeApi> {
+    pub first_swap_tokens: EsdtTokenPayment<M>,
+    pub second_swap_tokens: EsdtTokenPayment<M>,
+}
+
+pub struct PairAddLiqResult<M: ManagedTypeApi> {
+    pub lp_tokens: EsdtTokenPayment<M>,
+    pub first_tokens_remaining: EsdtTokenPayment<M>,
+    pub second_tokens_remaining: EsdtTokenPayment<M>,
+}
+
+#[elrond_wasm::module]
+pub trait PairActionsModule:
+    crate::configs::pairs_config::PairsConfigModule + utils::UtilsModule
+{
+    fn buy_half_each_token(
+        &self,
+        input_tokens: EsdtTokenPayment,
+        dest_pair: &ManagedAddress,
+    ) -> DoubleSwapResult<Self::Api> {
+        require!(input_tokens.token_nonce == 0, "Only fungible ESDT accepted");
+        self.require_sc_address(dest_pair);
+
+        let dest_pair_config = self.get_pair_config(dest_pair);
+        let tokens_to_pair_mapper = self.pair_address_for_tokens(
+            &dest_pair_config.first_token_id,
+            &dest_pair_config.second_token_id,
+        );
+        require!(!tokens_to_pair_mapper.is_empty(), "Unknown pair SC");
+
+        let first_amount = &input_tokens.amount / 2u32;
+        let second_amount = &input_tokens.amount - &first_amount;
+
+        let first_swap_tokens = self.perform_tokens_swap(
+            input_tokens.token_identifier.clone(),
+            first_amount,
+            dest_pair_config.first_token_id,
+        );
+        let second_swap_tokens = self.perform_tokens_swap(
+            input_tokens.token_identifier,
+            second_amount,
+            dest_pair_config.second_token_id,
+        );
+
+        DoubleSwapResult {
+            first_swap_tokens,
+            second_swap_tokens,
+        }
+    }
+
+    fn perform_tokens_swap(
+        &self,
+        from_tokens: TokenIdentifier,
+        from_amount: BigUint,
+        to_tokens: TokenIdentifier,
+    ) -> EsdtTokenPayment {
+        if from_tokens == to_tokens {
+            return EsdtTokenPayment::new(from_tokens, 0, from_amount);
+        }
+
+        let pair_address = self.get_pair_address_for_tokens(&from_tokens, &to_tokens);
+        let payment = EsdtTokenPayment::new(from_tokens, 0, from_amount);
+
+        self.call_pair_swap(pair_address, payment, to_tokens)
+    }
+
+    fn call_pair_swap(
+        &self,
+        pair_address: ManagedAddress,
+        input_tokens: EsdtTokenPayment,
+        requested_token_id: TokenIdentifier,
+    ) -> EsdtTokenPayment {
+        self.pair_proxy(pair_address)
+            .swap_tokens_fixed_input(requested_token_id, MIN_AMOUNT_OUT)
+            .with_esdt_transfer(input_tokens)
+            .execute_on_dest_context()
+    }
+
+    fn call_pair_add_liquidity(
+        &self,
+        pair_address: ManagedAddress,
+        first_tokens: EsdtTokenPayment,
+        second_tokens: EsdtTokenPayment,
+    ) -> PairAddLiqResult<Self::Api> {
+        let first_token_full_amount = first_tokens.amount.clone();
+        let second_token_full_amount = second_tokens.amount.clone();
+        let raw_results: AddLiquidityResultType<Self::Api> = self
+            .pair_proxy(pair_address)
+            .add_liquidity(MIN_AMOUNT_OUT, MIN_AMOUNT_OUT)
+            .with_esdt_transfer(first_tokens)
+            .with_esdt_transfer(second_tokens)
+            .execute_on_dest_context();
+
+        let (lp_tokens, first_tokens_used, second_tokens_used) = raw_results.into_tuple();
+        let first_tokens_remaining_amount = first_token_full_amount - first_tokens_used.amount;
+        let second_tokens_remaining_amount = second_token_full_amount - second_tokens_used.amount;
+
+        let first_tokens_remaining = EsdtTokenPayment::new(
+            first_tokens_used.token_identifier,
+            0,
+            first_tokens_remaining_amount,
+        );
+        let second_tokens_remaining = EsdtTokenPayment::new(
+            second_tokens_used.token_identifier,
+            0,
+            second_tokens_remaining_amount,
+        );
+
+        PairAddLiqResult {
+            lp_tokens,
+            first_tokens_remaining,
+            second_tokens_remaining,
+        }
+    }
+
+    #[proxy]
+    fn pair_proxy(&self, sc_address: ManagedAddress) -> pair::Proxy<Self::Api>;
+}

--- a/auto-pos-creator/src/lib.rs
+++ b/auto-pos-creator/src/lib.rs
@@ -2,8 +2,28 @@
 
 elrond_wasm::imports!();
 
+pub mod configs;
+pub mod external_sc_interactions;
+
 #[elrond_wasm::contract]
-pub trait AutoPosCreator {
+pub trait AutoPosCreator:
+    auto_farm::whitelists::farms_whitelist::FarmsWhitelistModule
+    + auto_farm::whitelists::metastaking_whitelist::MetastakingWhitelistModule
+    + auto_farm::external_storage_read::farm_storage_read::FarmStorageReadModule
+    + auto_farm::external_storage_read::metastaking_storage_read::MetastakingStorageReadModule
+    + utils::UtilsModule
+    + configs::auto_farm_config::AutoFarmConfigModule
+    + configs::pairs_config::PairsConfigModule
+    + external_sc_interactions::pair_actions::PairActionsModule
+    + external_sc_interactions::multi_contract_interactions::MultiContractInteractionsModule
+{
+    /// Auto-farm SC is only used to read the farms and metastaking addresses from it.
+    /// This way, we don't need to duplicate the setup in this SC as well
     #[init]
-    fn init(&self) {}
+    fn init(&self, auto_farm_sc_address: ManagedAddress) {
+        self.require_sc_address(&auto_farm_sc_address);
+
+        self.auto_farm_sc_address()
+            .set_if_empty(&auto_farm_sc_address);
+    }
 }

--- a/auto-pos-creator/wasm/src/lib.rs
+++ b/auto-pos-creator/wasm/src/lib.rs
@@ -5,15 +5,18 @@
 ////////////////////////////////////////////////////
 
 // Init:                                 1
-// Endpoints:                            0
+// Endpoints:                            3
 // Async Callback (empty):               1
-// Total number of exported functions:   2
+// Total number of exported functions:   5
 
 #![no_std]
 
 elrond_wasm_node::wasm_endpoints! {
     auto_pos_creator
     (
+        addPairsToWhitelist
+        removePairsFromWhitelist
+        createPosFromSingleToken
     )
 }
 


### PR DESCRIPTION
Part 1 of creating single position from input token. This PR adds an endpoint that allows the user to pay with any ESDT (P), and specify a destination pair, which will have the token pair (A, B)

The SC will search for a pair with input tokens (P, A) or (A, P), and swap half of P for A tokens.
Then, it will do the same for the (P, B) pair.

With the received A and B tokens, it will enter the requested pair. Further usage for the received LP tokens will come in a future PR.

Additional features added:
- get from address mechanism for AddressToId mapper
- using the new label system to not add unneeded endpoints from imported modules