### PR TITLE
enter farm with lp tokens

### DIFF
--- a/auto-pos-creator/src/common/mod.rs
+++ b/auto-pos-creator/src/common/mod.rs
@@ -1,0 +1,1 @@
+pub mod payments_wrapper;

--- a/auto-pos-creator/src/common/payments_wrapper.rs
+++ b/auto-pos-creator/src/common/payments_wrapper.rs
@@ -1,0 +1,45 @@
+use common_structs::PaymentsVec;
+
+elrond_wasm::imports!();
+
+pub struct PaymentsWraper<M: SendApi> {
+    payments: PaymentsVec<M>,
+}
+
+impl<M: SendApi> Default for PaymentsWraper<M> {
+    #[inline]
+    fn default() -> Self {
+        Self {
+            payments: PaymentsVec::new(),
+        }
+    }
+}
+
+impl<M: SendApi> PaymentsWraper<M> {
+    #[inline]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn push(&mut self, payment: EsdtTokenPayment<M>) {
+        if payment.amount == 0 {
+            return;
+        }
+
+        self.payments.push(payment);
+    }
+
+    pub fn send_and_return(self, to: &ManagedAddress<M>) -> PaymentsVec<M> {
+        if self.payments.is_empty() {
+            let _ = M::send_api_impl().multi_transfer_esdt_nft_execute(
+                to,
+                &self.payments,
+                0,
+                &ManagedBuffer::new(),
+                &ManagedArgBuffer::new(),
+            );
+        }
+
+        self.payments
+    }
+}

--- a/auto-pos-creator/src/common/payments_wrapper.rs
+++ b/auto-pos-creator/src/common/payments_wrapper.rs
@@ -31,14 +31,16 @@ impl<M: SendApi> PaymentsWraper<M> {
 
     pub fn send_and_return(self, to: &ManagedAddress<M>) -> PaymentsVec<M> {
         if self.payments.is_empty() {
-            let _ = M::send_api_impl().multi_transfer_esdt_nft_execute(
-                to,
-                &self.payments,
-                0,
-                &ManagedBuffer::new(),
-                &ManagedArgBuffer::new(),
-            );
+            return self.payments;
         }
+
+        let _ = M::send_api_impl().multi_transfer_esdt_nft_execute(
+            to,
+            &self.payments,
+            0,
+            &ManagedBuffer::new(),
+            &ManagedArgBuffer::new(),
+        );
 
         self.payments
     }

--- a/auto-pos-creator/src/external_sc_interactions/farm_actions.rs
+++ b/auto-pos-creator/src/external_sc_interactions/farm_actions.rs
@@ -1,0 +1,26 @@
+use farm::EnterFarmResultType;
+
+elrond_wasm::imports!();
+
+#[elrond_wasm::module]
+pub trait FarmActionsModule {
+    fn call_enter_farm(
+        &self,
+        farm_address: ManagedAddress,
+        user: ManagedAddress,
+        farming_tokens: EsdtTokenPayment,
+    ) -> EsdtTokenPayment {
+        let raw_results: EnterFarmResultType<Self::Api> = self
+            .farm_proxy(farm_address)
+            .enter_farm_endpoint(user)
+            .with_esdt_transfer(farming_tokens)
+            .execute_on_dest_context();
+
+        // no rewards on simple enter
+        let (new_farm_token, _) = raw_results.into_tuple();
+        new_farm_token
+    }
+
+    #[proxy]
+    fn farm_proxy(&self, sc_address: ManagedAddress) -> farm_with_locked_rewards::Proxy<Self::Api>;
+}

--- a/auto-pos-creator/src/external_sc_interactions/mod.rs
+++ b/auto-pos-creator/src/external_sc_interactions/mod.rs
@@ -1,2 +1,3 @@
+pub mod farm_actions;
 pub mod multi_contract_interactions;
 pub mod pair_actions;

--- a/auto-pos-creator/src/external_sc_interactions/multi_contract_interactions.rs
+++ b/auto-pos-creator/src/external_sc_interactions/multi_contract_interactions.rs
@@ -1,3 +1,8 @@
+use auto_farm::common::address_to_id_mapper::NULL_ID;
+use common_structs::PaymentsVec;
+
+use crate::common::payments_wrapper::PaymentsWraper;
+
 elrond_wasm::imports!();
 
 #[elrond_wasm::module]
@@ -5,15 +10,69 @@ pub trait MultiContractInteractionsModule:
     super::pair_actions::PairActionsModule
     + crate::configs::pairs_config::PairsConfigModule
     + utils::UtilsModule
+    + auto_farm::whitelists::farms_whitelist::FarmsWhitelistModule
+    + auto_farm::whitelists::metastaking_whitelist::MetastakingWhitelistModule
+    + auto_farm::external_storage_read::farm_storage_read::FarmStorageReadModule
+    + auto_farm::external_storage_read::metastaking_storage_read::MetastakingStorageReadModule
+    + crate::configs::auto_farm_config::AutoFarmConfigModule
+    + super::farm_actions::FarmActionsModule
 {
     #[endpoint(createPosFromSingleToken)]
-    fn create_pos_from_single_token(&self, dest_pair_address: ManagedAddress) {
+    fn create_pos_from_single_token(
+        &self,
+        dest_pair_address: ManagedAddress,
+    ) -> PaymentsVec<Self::Api> {
+        let caller = self.blockchain().get_caller();
         let payment = self.call_value().single_esdt();
         let double_swap_result = self.buy_half_each_token(payment, &dest_pair_address);
-        let _add_liq_result = self.call_pair_add_liquidity(
+        let add_liq_result = self.call_pair_add_liquidity(
             dest_pair_address,
             double_swap_result.first_swap_tokens,
             double_swap_result.second_swap_tokens,
         );
+
+        let mut output_payments = PaymentsWraper::new();
+        output_payments.push(add_liq_result.first_tokens_remaining);
+        output_payments.push(add_liq_result.second_tokens_remaining);
+
+        let auto_farm_address = self.auto_farm_sc_address().get();
+        let opt_farm_tokens =
+            self.try_enter_farm_with_lp(&add_liq_result.lp_tokens, &caller, &auto_farm_address);
+        if opt_farm_tokens.is_none() {
+            output_payments.push(add_liq_result.lp_tokens);
+
+            return output_payments.send_and_return(&caller);
+        }
+
+        let farm_tokens = unsafe { opt_farm_tokens.unwrap_unchecked() };
+        output_payments.push(farm_tokens);
+
+        output_payments.send_and_return(&caller)
+    }
+
+    fn try_enter_farm_with_lp(
+        &self,
+        lp_tokens: &EsdtTokenPayment,
+        user: &ManagedAddress,
+        auto_farm_address: &ManagedAddress,
+    ) -> Option<EsdtTokenPayment> {
+        let farm_id_for_lp_tokens = self
+            .farm_for_farming_token(&lp_tokens.token_identifier)
+            .get_from_address(&auto_farm_address);
+        if farm_id_for_lp_tokens == NULL_ID {
+            return None;
+        }
+
+        let opt_farm_address = self
+            .farm_ids()
+            .get_address_at_address(&auto_farm_address, farm_id_for_lp_tokens);
+        if opt_farm_address.is_none() {
+            return None;
+        }
+
+        let farm_address = unsafe { opt_farm_address.unwrap_unchecked() };
+        let farm_tokens = self.call_enter_farm(farm_address, user.clone(), lp_tokens.clone());
+
+        Some(farm_tokens)
     }
 }

--- a/auto-pos-creator/src/lib.rs
+++ b/auto-pos-creator/src/lib.rs
@@ -2,6 +2,7 @@
 
 elrond_wasm::imports!();
 
+pub mod common;
 pub mod configs;
 pub mod external_sc_interactions;
 
@@ -15,6 +16,7 @@ pub trait AutoPosCreator:
     + configs::auto_farm_config::AutoFarmConfigModule
     + configs::pairs_config::PairsConfigModule
     + external_sc_interactions::pair_actions::PairActionsModule
+    + external_sc_interactions::farm_actions::FarmActionsModule
     + external_sc_interactions::multi_contract_interactions::MultiContractInteractionsModule
 {
     /// Auto-farm SC is only used to read the farms and metastaking addresses from it.


### PR DESCRIPTION
Automatically enter a farm with the received LP tokens, if such a farm exists. Known farms list is read from the auto-farm SC, to not duplicate the storage.

Also added a `PaymentsWrapper` struct to deduplicate some checks.