### PR TITLE
enter metastaking with lp farm token

### DIFF
--- a/auto-pos-creator/src/external_sc_interactions/metastaking_actions.rs
+++ b/auto-pos-creator/src/external_sc_interactions/metastaking_actions.rs
@@ -1,0 +1,20 @@
+elrond_wasm::imports!();
+
+#[elrond_wasm::module]
+pub trait MetastakingActionsModule {
+    fn call_metastaking_stake(
+        &self,
+        sc_address: ManagedAddress,
+        user: ManagedAddress,
+        lp_farm_tokens: EsdtTokenPayment,
+    ) -> EsdtTokenPayment {
+        self.metastaking_proxy(sc_address)
+            .stake_farm_tokens(user)
+            .with_esdt_transfer(lp_farm_tokens)
+            .execute_on_dest_context()
+    }
+
+    #[proxy]
+    fn metastaking_proxy(&self, sc_address: ManagedAddress)
+        -> farm_staking_proxy::Proxy<Self::Api>;
+}

--- a/auto-pos-creator/src/external_sc_interactions/mod.rs
+++ b/auto-pos-creator/src/external_sc_interactions/mod.rs
@@ -1,3 +1,4 @@
 pub mod farm_actions;
+pub mod metastaking_actions;
 pub mod multi_contract_interactions;
 pub mod pair_actions;

--- a/auto-pos-creator/src/lib.rs
+++ b/auto-pos-creator/src/lib.rs
@@ -17,6 +17,7 @@ pub trait AutoPosCreator:
     + configs::pairs_config::PairsConfigModule
     + external_sc_interactions::pair_actions::PairActionsModule
     + external_sc_interactions::farm_actions::FarmActionsModule
+    + external_sc_interactions::metastaking_actions::MetastakingActionsModule
     + external_sc_interactions::multi_contract_interactions::MultiContractInteractionsModule
 {
     /// Auto-farm SC is only used to read the farms and metastaking addresses from it.


### PR DESCRIPTION
Automatically enter a metastaking SC if a mapping exists. As before, the storage from auto-farm SC is used.

Also fixed some clippy warnings.