### PR TITLE
full exit pos

### DIFF
--- a/auto-pos-creator/src/external_sc_interactions/metastaking_actions.rs
+++ b/auto-pos-creator/src/external_sc_interactions/metastaking_actions.rs
@@ -1,3 +1,7 @@
+use farm_staking_proxy::result_types::{StakeProxyResult, UnstakeResult};
+
+use super::pair_actions::MIN_AMOUNT_OUT;
+
 elrond_wasm::imports!();
 
 #[elrond_wasm::module]
@@ -7,10 +11,27 @@ pub trait MetastakingActionsModule {
         sc_address: ManagedAddress,
         user: ManagedAddress,
         lp_farm_tokens: EsdtTokenPayment,
-    ) -> EsdtTokenPayment {
+    ) -> StakeProxyResult<Self::Api> {
         self.metastaking_proxy(sc_address)
             .stake_farm_tokens(user)
             .with_esdt_transfer(lp_farm_tokens)
+            .execute_on_dest_context()
+    }
+
+    fn call_metastaking_unstake(
+        &self,
+        sc_address: ManagedAddress,
+        user: ManagedAddress,
+        dual_yield_tokens: EsdtTokenPayment,
+    ) -> UnstakeResult<Self::Api> {
+        self.metastaking_proxy(sc_address)
+            .unstake_farm_tokens(
+                MIN_AMOUNT_OUT,
+                MIN_AMOUNT_OUT,
+                dual_yield_tokens.amount.clone(),
+                user,
+            )
+            .with_esdt_transfer(dual_yield_tokens)
             .execute_on_dest_context()
     }
 

--- a/auto-pos-creator/src/external_sc_interactions/multi_contract_interactions.rs
+++ b/auto-pos-creator/src/external_sc_interactions/multi_contract_interactions.rs
@@ -3,6 +3,14 @@ use common_structs::PaymentsVec;
 
 use crate::common::payments_wrapper::PaymentsWraper;
 
+pub enum ExitType<M: ManagedTypeApi> {
+    Metastaking(ManagedAddress<M>),
+    Farm(ManagedAddress<M>),
+    Pair(ManagedAddress<M>),
+}
+
+static INVALID_INPUT_TOKEN_ERR_MSG: &[u8] = b"Invalid input token";
+
 elrond_wasm::imports!();
 
 #[elrond_wasm::module]
@@ -18,6 +26,7 @@ pub trait MultiContractInteractionsModule:
     + super::farm_actions::FarmActionsModule
     + super::metastaking_actions::MetastakingActionsModule
 {
+    #[payable("*")]
     #[endpoint(createPosFromSingleToken)]
     fn create_pos_from_single_token(
         &self,
@@ -100,9 +109,123 @@ pub trait MultiContractInteractionsModule:
         let ms_address = self
             .metastaking_ids()
             .get_address_at_address(auto_farm_address, ms_id_for_tokens)?;
-        let ms_tokens =
-            self.call_metastaking_stake(ms_address, user.clone(), lp_farm_tokens.clone());
+        let ms_tokens = self
+            .call_metastaking_stake(ms_address, user.clone(), lp_farm_tokens.clone())
+            .dual_yield_tokens;
 
         Some(ms_tokens)
+    }
+
+    #[payable("*")]
+    #[endpoint(fullExitPos)]
+    fn full_exit_pos(&self) -> PaymentsVec<Self::Api> {
+        let caller = self.blockchain().get_caller();
+        let payment = self.call_value().single_esdt();
+
+        let auto_farm_sc_address = self.auto_farm_sc_address().get();
+        let exit_type = self.get_exit_type(&payment.token_identifier, &auto_farm_sc_address);
+        let mut output_payments = PaymentsWraper::new();
+
+        match exit_type {
+            ExitType::Metastaking(ms_addr) => {
+                self.unstake_metastaking(&mut output_payments, ms_addr, caller.clone(), payment)
+            }
+            ExitType::Farm(farm_addr) => {
+                self.exit_farm(&mut output_payments, farm_addr, caller.clone(), payment)
+            }
+            ExitType::Pair(pair_addr) => {
+                self.remove_pair_liq(&mut output_payments, pair_addr, payment)
+            }
+        };
+
+        output_payments.send_and_return(&caller)
+    }
+
+    fn get_exit_type(
+        &self,
+        input_token: &TokenIdentifier,
+        auto_farm_address: &ManagedAddress,
+    ) -> ExitType<Self::Api> {
+        let ms_id = self
+            .metastaking_for_dual_yield_token(input_token)
+            .get_from_address(auto_farm_address);
+        if ms_id != NULL_ID {
+            let opt_ms_addr = self
+                .metastaking_ids()
+                .get_address_at_address(auto_farm_address, ms_id);
+            require!(opt_ms_addr.is_some(), INVALID_INPUT_TOKEN_ERR_MSG);
+
+            let ms_addr = unsafe { opt_ms_addr.unwrap_unchecked() };
+            return ExitType::Metastaking(ms_addr);
+        }
+
+        let farm_id = self
+            .farm_for_farm_token(input_token)
+            .get_from_address(auto_farm_address);
+        if farm_id != NULL_ID {
+            let opt_farm_addr = self
+                .farm_ids()
+                .get_address_at_address(auto_farm_address, farm_id);
+            require!(opt_farm_addr.is_some(), INVALID_INPUT_TOKEN_ERR_MSG);
+
+            let farm_addr = unsafe { opt_farm_addr.unwrap_unchecked() };
+            return ExitType::Farm(farm_addr);
+        }
+
+        let pair_addr_mapper = self.pair_for_lp_token(input_token);
+        require!(!pair_addr_mapper.is_empty(), INVALID_INPUT_TOKEN_ERR_MSG);
+
+        ExitType::Pair(pair_addr_mapper.get())
+    }
+
+    fn unstake_metastaking(
+        &self,
+        output_payments: &mut PaymentsWraper<Self::Api>,
+        ms_address: ManagedAddress,
+        user: ManagedAddress,
+        ms_tokens: EsdtTokenPayment,
+    ) {
+        let unstake_result = self.call_metastaking_unstake(ms_address, user, ms_tokens);
+        output_payments.push(unstake_result.other_token_payment);
+        output_payments.push(unstake_result.lp_farm_rewards);
+        output_payments.push(unstake_result.staking_rewards);
+        output_payments.push(unstake_result.unbond_staking_farm_token);
+
+        if let Some(new_dual_yield_tokens) = unstake_result.opt_new_dual_yield_tokens {
+            output_payments.push(new_dual_yield_tokens);
+        }
+    }
+
+    fn exit_farm(
+        &self,
+        output_payments: &mut PaymentsWraper<Self::Api>,
+        farm_address: ManagedAddress,
+        user: ManagedAddress,
+        farm_tokens: EsdtTokenPayment,
+    ) {
+        let exit_farm_result = self.call_exit_farm(farm_address, user, farm_tokens);
+        output_payments.push(exit_farm_result.rewards);
+
+        let lp_tokens = exit_farm_result.farming_tokens;
+        let pair_addr_mapper = self.pair_for_lp_token(&lp_tokens.token_identifier);
+        if pair_addr_mapper.is_empty() {
+            output_payments.push(lp_tokens);
+
+            return;
+        }
+
+        let pair_addr = pair_addr_mapper.get();
+        self.remove_pair_liq(output_payments, pair_addr, lp_tokens);
+    }
+
+    fn remove_pair_liq(
+        &self,
+        output_payments: &mut PaymentsWraper<Self::Api>,
+        pair_address: ManagedAddress,
+        lp_tokens: EsdtTokenPayment,
+    ) {
+        let remove_liq_result = self.call_pair_remove_liquidity(pair_address, lp_tokens);
+        output_payments.push(remove_liq_result.first_tokens);
+        output_payments.push(remove_liq_result.second_tokens);
     }
 }

--- a/auto-pos-creator/wasm/src/lib.rs
+++ b/auto-pos-creator/wasm/src/lib.rs
@@ -5,9 +5,9 @@
 ////////////////////////////////////////////////////
 
 // Init:                                 1
-// Endpoints:                            3
+// Endpoints:                            4
 // Async Callback (empty):               1
-// Total number of exported functions:   5
+// Total number of exported functions:   6
 
 #![no_std]
 
@@ -17,6 +17,7 @@ elrond_wasm_node::wasm_endpoints! {
         addPairsToWhitelist
         removePairsFromWhitelist
         createPosFromSingleToken
+        fullExitPos
     )
 }
 


### PR DESCRIPTION
Add an endpoint to full exit a position, based on the input token.
- for dual yield token, it will simply call the metastaking SC, as it already does everything
- for LP farm token, it will exit farm, and then remove liquidity
- for LP token, it will simply remove liquidity