### PR TITLE
Fix `tests-common` import issue

### DIFF
--- a/auto-farm/Cargo.toml
+++ b/auto-farm/Cargo.toml
@@ -57,4 +57,4 @@ pausable = { git = "https://github.com/multiversx/mx-exchange-sc", rev = "7b6564
 sc_whitelist_module = { git = "https://github.com/multiversx/mx-exchange-sc", rev = "7b6564f" }
 
 # Common test code
-tests-common = { path = "../tests-common" }
+tests-common = { path = "../tests-common", features = ["enable-tests-common"] }

--- a/auto-farm/tests/farm_claim_test.rs
+++ b/auto-farm/tests/farm_claim_test.rs
@@ -20,9 +20,9 @@ use auto_farm::user_tokens::user_rewards::UserRewardsModule;
 use auto_farm::whitelists::farms_whitelist::FarmsWhitelistModule;
 use auto_farm::AutoFarm;
 
-use crate::farm_with_locked_rewards_setup::{FarmSetup, FARM_TOKEN_ID, LOCKED_REWARD_TOKEN_ID};
-
-use tests_common::farm_with_locked_rewards_setup::*;
+use tests_common::farm_with_locked_rewards_setup::{
+    FarmSetup, FARM_TOKEN_ID, LOCKED_REWARD_TOKEN_ID,
+};
 
 const FEE_PERCENTAGE: u64 = 1_000; // 10%
 

--- a/auto-farm/tests/other_scs_claim_test.rs
+++ b/auto-farm/tests/other_scs_claim_test.rs
@@ -1,11 +1,7 @@
-pub mod farm_with_locked_rewards_setup;
 pub mod fees_collector_setup;
 pub mod metabonding_setup;
 
-use crate::{
-    farm_with_locked_rewards_setup::FarmSetup,
-    fees_collector_setup::{FIRST_TOKEN_ID, LOCKED_TOKEN_ID, SECOND_TOKEN_ID},
-};
+use crate::fees_collector_setup::{FIRST_TOKEN_ID, LOCKED_TOKEN_ID, SECOND_TOKEN_ID};
 use auto_farm::{
     common::{common_storage::MAX_PERCENTAGE, rewards_wrapper::RewardsWrapper},
     external_sc_interactions::fees_collector_actions::FeesCollectorActionsModule,
@@ -29,6 +25,7 @@ use energy_factory::locked_token_transfer::LockedTokenTransferModule;
 use fees_collector_setup::setup_fees_collector;
 use metabonding_setup::*;
 use sc_whitelist_module::SCWhitelistModule;
+use tests_common::farm_with_locked_rewards_setup::FarmSetup;
 
 const FEE_PERCENTAGE: u64 = 1_000; // 10%
 

--- a/auto-farm/tests/register_test.rs
+++ b/auto-farm/tests/register_test.rs
@@ -2,9 +2,7 @@ use auto_farm::common::common_storage::CommonStorageModule;
 use auto_farm::registration::RegistrationModule;
 use auto_farm::AutoFarm;
 use elrond_wasm_debug::{managed_address, rust_biguint};
-use farm_with_locked_rewards_setup::FarmSetup;
-
-use tests_common::farm_with_locked_rewards_setup::*;
+use tests_common::farm_with_locked_rewards_setup::FarmSetup;
 
 const FEE_PERCENTAGE: u64 = 1_000; // 10%
 

--- a/tests-common/Cargo.toml
+++ b/tests-common/Cargo.toml
@@ -8,6 +8,9 @@ publish = false
 [lib]
 path = "src/lib.rs"
 
+[features]
+enable-tests-common = []
+
 [dependencies.elrond-wasm]
 version = "=0.38.0"
 features = [ "esdt-token-payment-legacy-decode" ]
@@ -15,7 +18,7 @@ features = [ "esdt-token-payment-legacy-decode" ]
 [dependencies.elrond-wasm-modules]
 version = "=0.38.0"
 
-[dev-dependencies.elrond-wasm-debug]
+[dependencies.elrond-wasm-debug]
 version = "=0.38.0"
 
 # Farm dependencies
@@ -37,13 +40,12 @@ energy-query = { git = "https://github.com/multiversx/mx-exchange-sc", rev = "7b
 legacy_token_decode_module = { git = "https://github.com/multiversx/mx-exchange-sc", rev = "7b6564f" }
 lkmex-transfer = { git = "https://github.com/multiversx/mx-exchange-sc", rev = "7b6564f" }
 
-[dev-dependencies]
+# Dependencies needed for tests
 num-bigint = "0.4.2"
 num-traits = "0.2"
 hex = "0.4"
 hex-literal = "0.3.4"
 
-# Dependencies needed for tests
 simple-lock = { git = "https://github.com/multiversx/mx-exchange-sc", rev = "7b6564f" }
 farm-boosted-yields = { git = "https://github.com/multiversx/mx-exchange-sc", rev = "7b6564f" }
 config = { git = "https://github.com/multiversx/mx-exchange-sc", rev = "7b6564f" }

--- a/tests-common/src/farm_staking_setup/mod.rs
+++ b/tests-common/src/farm_staking_setup/mod.rs
@@ -1,4 +1,4 @@
-#![cfg(test)]
+#![cfg(feature = "enable-tests-common")]
 
 use elrond_wasm::storage::mappers::StorageTokenWrapper;
 use elrond_wasm::types::{EsdtLocalRole, ManagedAddress, MultiValueEncoded};

--- a/tests-common/src/farm_with_locked_rewards_setup/mod.rs
+++ b/tests-common/src/farm_with_locked_rewards_setup/mod.rs
@@ -1,4 +1,4 @@
-#![cfg(test)]
+#![cfg(feature = "enable-tests-common")]
 
 use config::ConfigModule;
 use elrond_wasm::{


### PR DESCRIPTION
Used the `enable-tests-common` feature flag to build the `tests-common` crate only when used by the tests, as suggested  [here](https://github.com/rust-lang/rust/issues/84629#issuecomment-886033427).
The usual `dev-dependencies` approach doesn't work because `cfg(test)` is not propagated to dependencies.