### PR TITLE
Balance token amounts for LP

### DIFF
--- a/auto-pos-creator/src/common/payments_wrapper.rs
+++ b/auto-pos-creator/src/common/payments_wrapper.rs
@@ -2,11 +2,11 @@ use common_structs::PaymentsVec;
 
 elrond_wasm::imports!();
 
-pub struct PaymentsWraper<M: SendApi> {
+pub struct PaymentsWrapper<M: SendApi> {
     payments: PaymentsVec<M>,
 }
 
-impl<M: SendApi> Default for PaymentsWraper<M> {
+impl<M: SendApi> Default for PaymentsWrapper<M> {
     #[inline]
     fn default() -> Self {
         Self {
@@ -15,7 +15,7 @@ impl<M: SendApi> Default for PaymentsWraper<M> {
     }
 }
 
-impl<M: SendApi> PaymentsWraper<M> {
+impl<M: SendApi> PaymentsWrapper<M> {
     #[inline]
     pub fn new() -> Self {
         Self::default()

--- a/auto-pos-creator/src/multi_contract_interactions/create_pos.rs
+++ b/auto-pos-creator/src/multi_contract_interactions/create_pos.rs
@@ -2,7 +2,7 @@ use auto_farm::common::address_to_id_mapper::NULL_ID;
 use common_structs::PaymentsVec;
 
 use crate::{
-    common::payments_wrapper::PaymentsWraper,
+    common::payments_wrapper::PaymentsWrapper,
     external_sc_interactions::pair_actions::PairTokenPayments,
 };
 
@@ -75,7 +75,7 @@ pub trait CreatePosModule:
             pair_input_tokens.second_tokens,
         );
 
-        let mut output_payments = PaymentsWraper::new();
+        let mut output_payments = PaymentsWrapper::new();
         output_payments.push(add_liq_result.first_tokens_remaining);
         output_payments.push(add_liq_result.second_tokens_remaining);
 

--- a/auto-pos-creator/src/multi_contract_interactions/exit_pos.rs
+++ b/auto-pos-creator/src/multi_contract_interactions/exit_pos.rs
@@ -1,7 +1,7 @@
 use auto_farm::common::address_to_id_mapper::NULL_ID;
 use common_structs::PaymentsVec;
 
-use crate::common::payments_wrapper::PaymentsWraper;
+use crate::common::payments_wrapper::PaymentsWrapper;
 
 elrond_wasm::imports!();
 
@@ -34,7 +34,7 @@ pub trait ExitPosModule:
 
         let auto_farm_sc_address = self.auto_farm_sc_address().get();
         let exit_type = self.get_exit_type(&payment.token_identifier, &auto_farm_sc_address);
-        let mut output_payments = PaymentsWraper::new();
+        let mut output_payments = PaymentsWrapper::new();
 
         match exit_type {
             ExitType::Metastaking(ms_addr) => {
@@ -90,7 +90,7 @@ pub trait ExitPosModule:
 
     fn unstake_metastaking(
         &self,
-        output_payments: &mut PaymentsWraper<Self::Api>,
+        output_payments: &mut PaymentsWrapper<Self::Api>,
         ms_address: ManagedAddress,
         user: ManagedAddress,
         ms_tokens: EsdtTokenPayment,
@@ -108,7 +108,7 @@ pub trait ExitPosModule:
 
     fn exit_farm(
         &self,
-        output_payments: &mut PaymentsWraper<Self::Api>,
+        output_payments: &mut PaymentsWrapper<Self::Api>,
         farm_address: ManagedAddress,
         user: ManagedAddress,
         farm_tokens: EsdtTokenPayment,
@@ -130,7 +130,7 @@ pub trait ExitPosModule:
 
     fn remove_pair_liq(
         &self,
-        output_payments: &mut PaymentsWraper<Self::Api>,
+        output_payments: &mut PaymentsWrapper<Self::Api>,
         pair_address: ManagedAddress,
         lp_tokens: EsdtTokenPayment,
     ) {


### PR DESCRIPTION
When user tries to create position from two tokens, first perform swaps if the ratio is not correct.

For example, if the user wants to enter the (A, B) pool with 100M A tokens, and 400M B tokens, but the pool's ratio is A:B 1:2, then swap half of the excess B tokens into A tokens. In this example, we would see that 100M A tokens are only worth 200B tokens, so we swap 200M / 2 B tokens for A tokens, which would leave us with close to 150M A tokens and 300B tokens.

Also fix a typo (`PaymentsWraper` -> `PaymentsWrapper`).

Added tests.