### PR TITLE
Basic setup for Rust snippets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
   "auto-farm",
   "auto-farm/meta",
+  "auto-farm/interact-rs",
   "auto-pos-creator",
   "auto-pos-creator/meta",
   "tests-common"

--- a/auto-farm/interact-rs/.gitignore
+++ b/auto-farm/interact-rs/.gitignore
@@ -1,0 +1,2 @@
+# Pem files are used for interactions, but shouldn't be committed
+*.pem

--- a/auto-farm/interact-rs/Cargo.toml
+++ b/auto-farm/interact-rs/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "rust-interact"
+version = "0.0.0"
+authors = ["you"]
+edition = "2021"
+publish = false
+
+[[bin]]
+name = "rust-interact"
+path = "src/lib.rs"
+
+[dependencies.auto-farm]
+path = ".."
+
+[dependencies.elrond-interact-snippets]
+version = "0.38.0"
+
+[dependencies]
+energy-query = { git = "https://github.com/multiversx/mx-exchange-sc", rev = "7b6564f" }

--- a/auto-farm/interact-rs/src/lib.rs
+++ b/auto-farm/interact-rs/src/lib.rs
@@ -1,0 +1,640 @@
+use auto_farm::external_storage_read::farm_storage_read::ProxyTrait as _;
+use auto_farm::external_storage_read::metastaking_storage_read::ProxyTrait as _;
+use auto_farm::fees::ProxyTrait as _;
+use auto_farm::registration::ProxyTrait as _;
+use auto_farm::user_tokens::user_farm_tokens::ProxyTrait as _;
+use auto_farm::user_tokens::user_metastaking_tokens::ProxyTrait as _;
+use auto_farm::user_tokens::user_rewards::ProxyTrait as _;
+use auto_farm::whitelists::farms_whitelist::ProxyTrait as _;
+use auto_farm::whitelists::metastaking_whitelist::ProxyTrait as _;
+#[allow(non_snake_case)]
+use auto_farm::ProxyTrait as _;
+use auto_farm::{
+    external_sc_interactions::multi_contract_interactions::ProxyTrait as _,
+    external_storage_read::farm_storage_read::FarmConfig,
+};
+use elrond_interact_snippets::{
+    elrond_wasm::{
+        elrond_codec::{multi_types::*, Empty},
+        types::{Address, CodeMetadata, MultiValueEncoded},
+    },
+    elrond_wasm_debug::{
+        bech32, mandos::interpret_trait::InterpreterContext, mandos_system::model::*, ContractInfo,
+        DebugApi,
+    },
+    env_logger,
+    erdrs::interactors::wallet::Wallet,
+    tokio, Interactor,
+};
+use energy_query::ProxyTrait as _;
+use std::{
+    env::Args,
+    io::{Read, Write},
+};
+
+const GATEWAY: &str = elrond_interact_snippets::erdrs::blockchain::rpc::DEVNET_GATEWAY;
+const PEM: &str = "devnetWalletKey.pem";
+const SC_ADDRESS: &str = "erd1qqqqqqqqqqqqqpgqnxsz48mu6m882qwq09dh66jxjdfm0rkk082s8r9fpp";
+
+const SYSTEM_SC_BECH32: &str = "erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzllls8a5w6u";
+const DEFAULT_ADDRESS_EXPR: &str =
+    "0x0000000000000000000000000000000000000000000000000000000000000000";
+const DEFAULT_GAS_LIMIT: u64 = 100_000_000;
+const TOKEN_ISSUE_COST: u64 = 50_000_000_000_000_000;
+
+type ContractType = ContractInfo<auto_farm::Proxy<DebugApi>>;
+
+/// Setup steps:
+/// - deploy
+/// - addFarms (farms and farm-staking are both added through this endpoint)
+///     No additional setup is needed, as the auto-farm SC will read the required data from the farm's storage
+/// - addMetastakingScs (optional)
+/// 
+/// User actions:
+/// - register (for users who only want fees-collector/metabonding, without any farm interactions)
+/// - depositFarmTokens (deposits farm tokens, and also registers the user)
+/// - depositMetastakingTokens (similar to the one above, but for metastaking, i.e. dual yield tokens)
+/// - withdrawAllFarmTokens, withdrawSpecificFarmTokens
+/// - withdrawAllMetastakingTokens, withdrawSpecificMetastakingTokens
+/// - withdrawAllAndUnregister
+/// - userClaimRewards - claim accumulated rewards
+/// 
+/// Proxy actions:
+/// - claimAllRewardsAndCompound - claims all rewards from all contracts (metabonding, fees collector, farms, etc.)
+///     and compounds those rewards with a user's existing farm position, if they have any that fit
+///     (i.e. farming token == reward token). These will generally be farm-staking contracts.
+/// - claimFees - on each claim, a part is taken as fees from the user. These fees can be claimed with this endpoint.
+
+#[tokio::main]
+async fn main() {
+    env_logger::init();
+    let _ = DebugApi::dummy();
+
+    let mut args = std::env::args();
+    let _ = args.next();
+    let cmd = args.next().expect("at least one argument required");
+    let mut state = State::new().await;
+    match cmd.as_str() {
+        "deploy" => state.deploy().await,
+        "changeProxyClaimAddress" => state.change_proxy_claim_address().await,
+        "addFarms" => state.add_farms().await,
+        "removeFarms" => state.remove_farms().await,
+        "getFarmForFarmToken" => state.get_farm_for_farm_token_view().await,
+        "getFarmForFarmingToken" => state.get_farm_for_farming_token_view().await,
+        "getFarmConfig" => state.get_farm_config().await,
+        "register" => state.register().await,
+        "withdrawAllAndUnregister" => state.withdraw_all_and_unregister().await,
+        "depositFarmTokens" => state.deposit_farm_tokens().await,
+        "withdrawAllFarmTokens" => state.withdraw_all_farm_tokens_endpoint().await,
+        "withdrawSpecificFarmTokens" => state.withdraw_specific_farm_tokens_endpoint().await,
+        "getUserFarmTokens" => state.get_user_farm_tokens_view().await,
+        "addMetastakingScs" => state.add_metastaking_scs().await,
+        "removeMetastakingScs" => state.remove_metastaking_scs().await,
+        "getMetastakingForDualYieldToken" => {
+            state.get_metastaking_for_dual_yield_token_view().await
+        }
+        "getMetastakingForLpFarmToken" => state.get_metastaking_for_lp_farm_token().await,
+        "depositMetastakingTokens" => state.deposit_metastaking_tokens().await,
+        "withdrawAllMetastakingTokens" => state.withdraw_all_metastaking_tokens_endpoint().await,
+        "withdrawSpecificMetastakingTokens" => {
+            state.withdraw_specific_metastaking_tokens_endpoint().await
+        }
+        "getUserMetastakingTokens" => state.get_user_metastaking_tokens_view().await,
+        "getMetastakingConfig" => state.get_metastaking_config().await,
+        "claimAllRewardsAndCompound" => state.claim_all_rewards_and_compound().await,
+        "userClaimRewards" => state.user_claim_rewards_endpoint().await,
+        "getUserRewards" => state.get_user_rewards_view().await,
+        "claimFees" => state.claim_fees().await,
+        "getFeePercentage" => state.fee_percentage().await,
+        "getAccumulatedFees" => state.accumulated_fees().await,
+        "setEnergyFactoryAddress" => state.set_energy_factory_address().await,
+        "getEnergyFactoryAddress" => state.energy_factory_address().await,
+        _ => panic!("unknown command: {}", &cmd),
+    }
+}
+
+struct State {
+    interactor: Interactor,
+    wallet_address: Address,
+    contract: ContractType,
+}
+
+impl State {
+    async fn new() -> Self {
+        let mut interactor = Interactor::new(GATEWAY).await;
+        let wallet_address = interactor.register_wallet(Wallet::from_pem_file(PEM).unwrap());
+        let sc_addr_expr = if SC_ADDRESS == "" {
+            DEFAULT_ADDRESS_EXPR.to_string()
+        } else {
+            "bech32:".to_string() + SC_ADDRESS
+        };
+        let contract = ContractType::new(sc_addr_expr);
+
+        State {
+            interactor,
+            wallet_address,
+            contract,
+        }
+    }
+
+    async fn deploy(&mut self) {
+        let proxy_claim_address = self.wallet_address.clone();
+        let fee_percentage = 1_000u64; // 10%
+        let energy_factory_address =
+            bech32::decode("erd1qqqqqqqqqqqqqpgqp6qrf7yp4l25c08384vgdghz7wz0f60h0n4s0m88l4");
+        let metabonding_sc_address = energy_factory_address.clone(); // not used here
+        let fees_collector_sc_address =
+            bech32::decode("erd1qqqqqqqqqqqqqpgq82pd37ra5vqnsaq5cc50ll073gzm4ahx0n4s793d9d");
+
+        let result: elrond_interact_snippets::InteractorResult<()> = self
+            .interactor
+            .sc_deploy(
+                self.contract
+                    .init(
+                        proxy_claim_address,
+                        fee_percentage,
+                        energy_factory_address,
+                        metabonding_sc_address,
+                        fees_collector_sc_address,
+                    )
+                    .into_blockchain_call()
+                    .from(&self.wallet_address)
+                    .code_metadata(CodeMetadata::all())
+                    .contract_code(
+                        "file:../output/auto-farm.wasm",
+                        &InterpreterContext::default(),
+                    )
+                    .gas_limit(DEFAULT_GAS_LIMIT),
+            )
+            .await;
+
+        let new_address = result.new_deployed_address();
+        let new_address_bech32 = bech32::encode(&new_address);
+        println!("new address: {}", new_address_bech32);
+        let result_value = result.value();
+
+        println!("Result: {:?}", result_value);
+    }
+
+    async fn change_proxy_claim_address(&mut self) {
+        let new_proxy_claim_address = PlaceholderInput;
+
+        let result: elrond_interact_snippets::InteractorResult<PlaceholderOutput> = self
+            .interactor
+            .sc_call_get_result(
+                self.contract
+                    .change_proxy_claim_address(new_proxy_claim_address)
+                    .into_blockchain_call()
+                    .from(&self.wallet_address)
+                    .gas_limit(DEFAULT_GAS_LIMIT)
+                    .into(),
+            )
+            .await;
+        let result_value = result.value();
+
+        println!("Result: {:?}", result_value);
+    }
+
+    async fn add_farms(&mut self) {
+        let mut farms = MultiValueVec::new();
+        farms.push(bech32::decode(
+            "erd1qqqqqqqqqqqqqpgq6wrtdnv7d5uypnaw2k8mtujfdl0s66t40n4sag5e7n",
+        ));
+        farms.push(bech32::decode(
+            "erd1qqqqqqqqqqqqqpgqv6j2vr8tr9rc0fwhu0s2xef9w64qww2h0n4ssmxgq0",
+        ));
+        farms.push(bech32::decode(
+            "erd1qqqqqqqqqqqqqpgq5dzs6yf47tnsk5ays2aedzmu2ahsmcqv0n4s3rsljy",
+        ));
+
+        let result: elrond_interact_snippets::InteractorResult<()> = self
+            .interactor
+            .sc_call_get_result(
+                self.contract
+                    .add_farms(farms)
+                    .into_blockchain_call()
+                    .from(&self.wallet_address)
+                    .gas_limit(DEFAULT_GAS_LIMIT)
+                    .into(),
+            )
+            .await;
+        let result_value = result.value();
+
+        println!("Result: {:?}", result_value);
+    }
+
+    async fn remove_farms(&mut self) {
+        let farms = PlaceholderInput;
+
+        let result: elrond_interact_snippets::InteractorResult<PlaceholderOutput> = self
+            .interactor
+            .sc_call_get_result(
+                self.contract
+                    .remove_farms(farms)
+                    .into_blockchain_call()
+                    .from(&self.wallet_address)
+                    .gas_limit(DEFAULT_GAS_LIMIT)
+                    .into(),
+            )
+            .await;
+        let result_value = result.value();
+
+        println!("Result: {:?}", result_value);
+    }
+
+    async fn get_farm_for_farm_token_view(&mut self) {
+        // let farm_token_id = PlaceholderInput;
+
+        // let result_value: PlaceholderOutput = self
+        //     .interactor
+        //     .vm_query(self.contract.get_farm_for_farm_token_view(farm_token_id))
+        //     .await;
+
+        // println!("Result: {:?}", result_value);
+    }
+
+    async fn get_farm_for_farming_token_view(&mut self) {
+        // let farming_token_id = PlaceholderInput;
+
+        // let result_value: PlaceholderOutput = self
+        //     .interactor
+        //     .vm_query(
+        //         self.contract
+        //             .get_farm_for_farming_token_view(farming_token_id),
+        //     )
+        //     .await;
+
+        // println!("Result: {:?}", result_value);
+    }
+
+    async fn get_farm_config(&mut self) {
+        let farm_address =
+            bech32::decode("erd1qqqqqqqqqqqqqpgq6wrtdnv7d5uypnaw2k8mtujfdl0s66t40n4sag5e7n");
+
+        let result_value: FarmConfig<DebugApi> = self
+            .interactor
+            .vm_query(self.contract.get_farm_config(farm_address))
+            .await;
+
+        println!("Result: {:?}", result_value);
+    }
+
+    async fn register(&mut self) {
+        let result: elrond_interact_snippets::InteractorResult<PlaceholderOutput> = self
+            .interactor
+            .sc_call_get_result(
+                self.contract
+                    .register()
+                    .into_blockchain_call()
+                    .from(&self.wallet_address)
+                    .gas_limit(DEFAULT_GAS_LIMIT)
+                    .into(),
+            )
+            .await;
+        let result_value = result.value();
+
+        println!("Result: {:?}", result_value);
+    }
+
+    async fn withdraw_all_and_unregister(&mut self) {
+        let result: elrond_interact_snippets::InteractorResult<PlaceholderOutput> = self
+            .interactor
+            .sc_call_get_result(
+                self.contract
+                    .withdraw_all_and_unregister()
+                    .into_blockchain_call()
+                    .from(&self.wallet_address)
+                    .gas_limit(DEFAULT_GAS_LIMIT)
+                    .into(),
+            )
+            .await;
+        let result_value = result.value();
+
+        println!("Result: {:?}", result_value);
+    }
+
+    async fn deposit_farm_tokens(&mut self) {
+        let token_id = b"";
+        let token_nonce = 0u64;
+        let token_amount = 0u64;
+
+        let result: elrond_interact_snippets::InteractorResult<PlaceholderOutput> = self
+            .interactor
+            .sc_call_get_result(
+                self.contract
+                    .deposit_farm_tokens()
+                    .into_blockchain_call()
+                    .from(&self.wallet_address)
+                    .esdt_transfer(token_id.to_vec(), token_nonce, token_amount)
+                    .gas_limit(DEFAULT_GAS_LIMIT)
+                    .into(),
+            )
+            .await;
+        let result_value = result.value();
+
+        println!("Result: {:?}", result_value);
+    }
+
+    async fn withdraw_all_farm_tokens_endpoint(&mut self) {
+        let result: elrond_interact_snippets::InteractorResult<PlaceholderOutput> = self
+            .interactor
+            .sc_call_get_result(
+                self.contract
+                    .withdraw_all_farm_tokens_endpoint()
+                    .into_blockchain_call()
+                    .from(&self.wallet_address)
+                    .gas_limit(DEFAULT_GAS_LIMIT)
+                    .into(),
+            )
+            .await;
+        let result_value = result.value();
+
+        println!("Result: {:?}", result_value);
+    }
+
+    async fn withdraw_specific_farm_tokens_endpoint(&mut self) {
+        let tokens_to_withdraw = PlaceholderInput;
+
+        let result: elrond_interact_snippets::InteractorResult<PlaceholderOutput> = self
+            .interactor
+            .sc_call_get_result(
+                self.contract
+                    .withdraw_specific_farm_tokens_endpoint(tokens_to_withdraw)
+                    .into_blockchain_call()
+                    .from(&self.wallet_address)
+                    .gas_limit(DEFAULT_GAS_LIMIT)
+                    .into(),
+            )
+            .await;
+        let result_value = result.value();
+
+        println!("Result: {:?}", result_value);
+    }
+
+    async fn get_user_farm_tokens_view(&mut self) {
+        let user = PlaceholderInput;
+
+        let result_value: PlaceholderOutput = self
+            .interactor
+            .vm_query(self.contract.get_user_farm_tokens_view(user))
+            .await;
+
+        println!("Result: {:?}", result_value);
+    }
+
+    async fn add_metastaking_scs(&mut self) {
+        let scs = PlaceholderInput;
+
+        let result: elrond_interact_snippets::InteractorResult<PlaceholderOutput> = self
+            .interactor
+            .sc_call_get_result(
+                self.contract
+                    .add_metastaking_scs(scs)
+                    .into_blockchain_call()
+                    .from(&self.wallet_address)
+                    .gas_limit(DEFAULT_GAS_LIMIT)
+                    .into(),
+            )
+            .await;
+        let result_value = result.value();
+
+        println!("Result: {:?}", result_value);
+    }
+
+    async fn remove_metastaking_scs(&mut self) {
+        let scs = PlaceholderInput;
+
+        let result: elrond_interact_snippets::InteractorResult<PlaceholderOutput> = self
+            .interactor
+            .sc_call_get_result(
+                self.contract
+                    .remove_metastaking_scs(scs)
+                    .into_blockchain_call()
+                    .from(&self.wallet_address)
+                    .gas_limit(DEFAULT_GAS_LIMIT)
+                    .into(),
+            )
+            .await;
+        let result_value = result.value();
+
+        println!("Result: {:?}", result_value);
+    }
+
+    async fn get_metastaking_for_dual_yield_token_view(&mut self) {
+        // let dual_yield_token_id = PlaceholderInput;
+
+        // let result_value: PlaceholderOutput = self
+        //     .interactor
+        //     .vm_query(
+        //         self.contract
+        //             .get_metastaking_for_dual_yield_token_view(dual_yield_token_id),
+        //     )
+        //     .await;
+
+        // println!("Result: {:?}", result_value);
+    }
+
+    async fn get_metastaking_for_lp_farm_token(&mut self) {
+        // let lp_farm_token_id = PlaceholderInput;
+
+        // let result_value: PlaceholderOutput = self
+        //     .interactor
+        //     .vm_query(
+        //         self.contract
+        //             .get_metastaking_for_lp_farm_token(lp_farm_token_id),
+        //     )
+        //     .await;
+
+        // println!("Result: {:?}", result_value);
+    }
+
+    async fn deposit_metastaking_tokens(&mut self) {
+        let token_id = b"";
+        let token_nonce = 0u64;
+        let token_amount = 0u64;
+
+        let result: elrond_interact_snippets::InteractorResult<PlaceholderOutput> = self
+            .interactor
+            .sc_call_get_result(
+                self.contract
+                    .deposit_metastaking_tokens()
+                    .into_blockchain_call()
+                    .from(&self.wallet_address)
+                    .esdt_transfer(token_id.to_vec(), token_nonce, token_amount)
+                    .gas_limit(DEFAULT_GAS_LIMIT)
+                    .into(),
+            )
+            .await;
+        let result_value = result.value();
+
+        println!("Result: {:?}", result_value);
+    }
+
+    async fn withdraw_all_metastaking_tokens_endpoint(&mut self) {
+        let result: elrond_interact_snippets::InteractorResult<PlaceholderOutput> = self
+            .interactor
+            .sc_call_get_result(
+                self.contract
+                    .withdraw_all_metastaking_tokens_endpoint()
+                    .into_blockchain_call()
+                    .from(&self.wallet_address)
+                    .gas_limit(DEFAULT_GAS_LIMIT)
+                    .into(),
+            )
+            .await;
+        let result_value = result.value();
+
+        println!("Result: {:?}", result_value);
+    }
+
+    async fn withdraw_specific_metastaking_tokens_endpoint(&mut self) {
+        let tokens_to_withdraw = PlaceholderInput;
+
+        let result: elrond_interact_snippets::InteractorResult<PlaceholderOutput> = self
+            .interactor
+            .sc_call_get_result(
+                self.contract
+                    .withdraw_specific_metastaking_tokens_endpoint(tokens_to_withdraw)
+                    .into_blockchain_call()
+                    .from(&self.wallet_address)
+                    .gas_limit(DEFAULT_GAS_LIMIT)
+                    .into(),
+            )
+            .await;
+        let result_value = result.value();
+
+        println!("Result: {:?}", result_value);
+    }
+
+    async fn get_user_metastaking_tokens_view(&mut self) {
+        let user = PlaceholderInput;
+
+        let result_value: PlaceholderOutput = self
+            .interactor
+            .vm_query(self.contract.get_user_metastaking_tokens_view(user))
+            .await;
+
+        println!("Result: {:?}", result_value);
+    }
+
+    async fn get_metastaking_config(&mut self) {
+        let metastaking_address = PlaceholderInput;
+
+        let result_value: PlaceholderOutput = self
+            .interactor
+            .vm_query(self.contract.get_metastaking_config(metastaking_address))
+            .await;
+
+        println!("Result: {:?}", result_value);
+    }
+
+    async fn claim_all_rewards_and_compound(&mut self) {
+        let claim_args = PlaceholderInput;
+
+        let result: elrond_interact_snippets::InteractorResult<PlaceholderOutput> = self
+            .interactor
+            .sc_call_get_result(
+                self.contract
+                    .claim_all_rewards_and_compound(claim_args)
+                    .into_blockchain_call()
+                    .from(&self.wallet_address)
+                    .gas_limit(DEFAULT_GAS_LIMIT)
+                    .into(),
+            )
+            .await;
+        let result_value = result.value();
+
+        println!("Result: {:?}", result_value);
+    }
+
+    async fn user_claim_rewards_endpoint(&mut self) {
+        let result: elrond_interact_snippets::InteractorResult<PlaceholderOutput> = self
+            .interactor
+            .sc_call_get_result(
+                self.contract
+                    .user_claim_rewards_endpoint()
+                    .into_blockchain_call()
+                    .from(&self.wallet_address)
+                    .gas_limit(DEFAULT_GAS_LIMIT)
+                    .into(),
+            )
+            .await;
+        let result_value = result.value();
+
+        println!("Result: {:?}", result_value);
+    }
+
+    async fn get_user_rewards_view(&mut self) {
+        let user = PlaceholderInput;
+
+        let result_value: PlaceholderOutput = self
+            .interactor
+            .vm_query(self.contract.get_user_rewards_view(user))
+            .await;
+
+        println!("Result: {:?}", result_value);
+    }
+
+    async fn claim_fees(&mut self) {
+        let result: elrond_interact_snippets::InteractorResult<PlaceholderOutput> = self
+            .interactor
+            .sc_call_get_result(
+                self.contract
+                    .claim_fees()
+                    .into_blockchain_call()
+                    .from(&self.wallet_address)
+                    .gas_limit(DEFAULT_GAS_LIMIT)
+                    .into(),
+            )
+            .await;
+        let result_value = result.value();
+
+        println!("Result: {:?}", result_value);
+    }
+
+    async fn fee_percentage(&mut self) {
+        let result_value: PlaceholderOutput = self
+            .interactor
+            .vm_query(self.contract.fee_percentage())
+            .await;
+
+        println!("Result: {:?}", result_value);
+    }
+
+    async fn accumulated_fees(&mut self) {
+        let result_value: PlaceholderOutput = self
+            .interactor
+            .vm_query(self.contract.accumulated_fees())
+            .await;
+
+        println!("Result: {:?}", result_value);
+    }
+
+    async fn set_energy_factory_address(&mut self) {
+        let sc_address = PlaceholderInput;
+
+        let result: elrond_interact_snippets::InteractorResult<PlaceholderOutput> = self
+            .interactor
+            .sc_call_get_result(
+                self.contract
+                    .set_energy_factory_address(sc_address)
+                    .into_blockchain_call()
+                    .from(&self.wallet_address)
+                    .gas_limit(DEFAULT_GAS_LIMIT)
+                    .into(),
+            )
+            .await;
+        let result_value = result.value();
+
+        println!("Result: {:?}", result_value);
+    }
+
+    async fn energy_factory_address(&mut self) {
+        let result_value: PlaceholderOutput = self
+            .interactor
+            .vm_query(self.contract.energy_factory_address())
+            .await;
+
+        println!("Result: {:?}", result_value);
+    }
+}

--- a/auto-farm/interact-rs/src/lib.rs
+++ b/auto-farm/interact-rs/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(non_snake_case)]
+
 use auto_farm::external_storage_read::farm_storage_read::ProxyTrait as _;
 use auto_farm::external_storage_read::metastaking_storage_read::ProxyTrait as _;
 use auto_farm::fees::ProxyTrait as _;
@@ -7,7 +9,6 @@ use auto_farm::user_tokens::user_metastaking_tokens::ProxyTrait as _;
 use auto_farm::user_tokens::user_rewards::ProxyTrait as _;
 use auto_farm::whitelists::farms_whitelist::ProxyTrait as _;
 use auto_farm::whitelists::metastaking_whitelist::ProxyTrait as _;
-#[allow(non_snake_case)]
 use auto_farm::ProxyTrait as _;
 use auto_farm::{
     external_sc_interactions::multi_contract_interactions::ProxyTrait as _,

--- a/auto-farm/src/external_storage_read/farm_storage_read.rs
+++ b/auto-farm/src/external_storage_read/farm_storage_read.rs
@@ -10,7 +10,7 @@ pub enum State {
     PartialActive,
 }
 
-#[derive(TypeAbi, TopEncode, TopDecode)]
+#[derive(TypeAbi, TopEncode, TopDecode, Debug)]
 pub struct FarmConfig<M: ManagedTypeApi> {
     pub state: State,
     pub farm_token_id: TokenIdentifier<M>,

--- a/auto-farm/wasm/src/lib.rs
+++ b/auto-farm/wasm/src/lib.rs
@@ -15,7 +15,6 @@ elrond_wasm_node::wasm_endpoints! {
     auto_farm
     (
         changeProxyClaimAddress
-        getFarmConfig
         register
         withdrawAllAndUnregister
         depositFarmTokens
@@ -26,7 +25,6 @@ elrond_wasm_node::wasm_endpoints! {
         withdrawAllMetastakingTokens
         withdrawSpecificMetastakingTokens
         getUserMetastakingTokens
-        getMetastakingConfig
         claimAllRewardsAndCompound
         userClaimRewards
         getUserRewards
@@ -39,10 +37,12 @@ elrond_wasm_node::wasm_endpoints! {
         removeFarms
         getFarmForFarmToken
         getFarmForFarmingToken
+        getFarmConfig
         addMetastakingScs
         removeMetastakingScs
         getMetastakingForDualYieldToken
         getMetastakingForLpFarmToken
+        getMetastakingConfig
     )
 }
 


### PR DESCRIPTION
How to generate:
- cd auto-farm/meta
- run `cargo run snippets` in the terminal, which will generate the `interact-rs` folder
- cd ../interact-rs
- build the snippets: `cargo build`
- to run a function: `cargo run nameHere`

Unfortunately, some manual work is required to have a buildable version of the snippets. Work is being done on this to improve it.

Additionally, each function will need to have values for the arguments added, and the output type replaced manually.